### PR TITLE
fix: calender disappearing on livewire update

### DIFF
--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -1,11 +1,18 @@
 <x-filament::widget>
     <x-filament::card>
-        <div x-data="" x-init='document.addEventListener("DOMContentLoaded", () => {
+        <div wire:ignore x-data="" x-init='document.addEventListener("DOMContentLoaded", () => {
             const calendar = new FullCalendar.Calendar($el, Object.assign(
                 @json($this->getConfig()),
                 {
                     events: @json($events),
-                    eventClick: ({ event }) => @js($this->isListeningClickEvent()) && window.livewire.find("{{ $this->id }}").onEventClick(event),
+                    eventClick: ({ event, jsEvent }) => {
+                        if(event.url) {
+                            jsEvent.preventDefault();
+                            window.open(event.url, "_blank");
+                            return false;
+                        }
+                        @js($this->isListeningClickEvent()) && window.livewire.find("{{ $this->id }}").onEventClick(event)
+                    },
                     eventDrop:  ({ event, oldEvent, relatedEvents }) => @js($this->isListeningDropEvent()) && window.livewire.find("{{ $this->id }}").onEventDrop(event, oldEvent, relatedEvents),
                 }
             ));


### PR DESCRIPTION
This also fixes the event url