### PR TITLE
feat: add calendar select event

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # Features
 
 - Accepts all configurations from [FullCalendar](https://fullcalendar.io/docs#toc)
-- Event click and drop events
+- Event click, drop and select events
 - Modals for creating and editing events <sup>New in v1.0</sup>
 
 <br>
@@ -124,6 +124,8 @@ return [
 
     'editable' => true,
 
+    'selectable' => true,
+
     'dayMaxEvents' => true
 ];
 ```
@@ -132,7 +134,7 @@ return [
 
 # Listening for events
 
-The only events supported right now are: [EventClick](https://fullcalendar.io/docs/eventClick) and [EventDrop](https://fullcalendar.io/docs/eventDrop)
+The only events supported right now are: [EventClick](https://fullcalendar.io/docs/eventClick), [EventDrop](https://fullcalendar.io/docs/eventDrop) and [Select](https://fullcalendar.io/docs/select-callback)
 
 They're commented out by default so livewire does not spam requests without they being used. You are free to paste them in your `CalendarWidget` class. See: [FiresEvents](https://github.com/saade/filament-fullcalendar/blob/main/src/Widgets/Concerns/FiresEvents.php)
 
@@ -155,6 +157,16 @@ public function onEventClick($event): void
 public function onEventDrop($oldEvent, $newEvent, $relatedEvents): void
 {
     parent::onEventDrop($oldEvent, $newEvent, $relatedEvents);
+
+    // your code
+}
+
+/**
+ * Triggered when a date/time selection is made.
+ */
+public function onEventSelect(string $start, string $end, bool $allDay): void
+{
+    parent::onEventSelect($start, $end, $allDay);
 
     // your code
 }
@@ -229,7 +241,7 @@ protected static function getEditEventFormSchema(): array
 
 ## Authorizing actions
 
-If you want to authorize the `edit` or `create` action, you can override the default authorization methods that comes with this package.
+If you want to authorize the `edit`, `create` or `select` action, you can override the default authorization methods that comes with this package.
 
 ```php
 public static function canCreate(): bool
@@ -241,6 +253,12 @@ public static function canCreate(): bool
 public static function canEdit(?array $event = null): bool
 {
     // Returning 'false' will disable the edit modal when clicking on a event.
+    return true;
+}
+
+public static function canSelect(?string $start = null, ?string $end = null, ?bool $allDay = null): bool
+{
+    // Returning 'false' will disable the create modal when selecting a date.
     return true;
 }
 ```

--- a/config/filament-fullcalendar.php
+++ b/config/filament-fullcalendar.php
@@ -21,5 +21,7 @@ return [
 
     'editable' => true,
 
+    'selectable' => true,
+
     'dayMaxEvents' => true
 ];

--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -39,12 +39,19 @@
                         @endif
                     }
 
+                    const select = function ({ start, end, allDay }) {
+                        @if ($this::isListeningSelectEvent())
+                            $wire.onEventSelect(start, end, allDay)
+                        @endif
+                    }
+
                     const calendar = new FullCalendar.Calendar($el, {
                         ...config,
                         locale,
                         events,
                         eventClick,
-                        eventDrop
+                        eventDrop,
+                        select,
                     });
 
                     calendar.render();

--- a/src/Widgets/Concerns/AuthorizesActions.php
+++ b/src/Widgets/Concerns/AuthorizesActions.php
@@ -14,6 +14,11 @@ trait AuthorizesActions
         return true;
     }
 
+    public static function canSelect(?string $start = null, ?string $end = null, ?bool $allDay = null): bool
+    {
+        return true;
+    }
+
     public static function canDelete(?array $event = null): bool
     {
         return true;

--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -49,4 +49,15 @@ trait CanManageEvents
 
         $this->dispatchBrowserEvent('open-modal', ['id' => 'fullcalendar--create-event-modal']);
     }
+
+    public function onEventSelect(string $start, string $end, bool $allDay): void
+    {
+        if (! static::canSelect()) {
+            return;
+        }
+
+        $this->createEventForm->fill(['start' => $start, 'end' => $end, 'allDay' => $allDay]);
+
+        $this->dispatchBrowserEvent('open-modal', ['id' => 'fullcalendar--create-event-modal']);
+    }
 }

--- a/src/Widgets/Concerns/CantManageEvents.php
+++ b/src/Widgets/Concerns/CantManageEvents.php
@@ -14,6 +14,11 @@ trait CantManageEvents
         return false;
     }
 
+    public static function canSelect(?string $start = null, ?string $end = null, ?bool $allDay = null): bool
+    {
+        return false;
+    }
+
     public static function canDelete(?array $event = null): bool
     {
         return false;

--- a/src/Widgets/Concerns/FiresEvents.php
+++ b/src/Widgets/Concerns/FiresEvents.php
@@ -35,4 +35,20 @@ trait FiresEvents
     {
         return method_exists(static::class, 'onEventDrop');
     }
+
+    /**
+     * Triggered when a date/time selection is made.
+     *
+     * Commented out so we can save some requests :) Feel free to extend it.
+     * @see https://fullcalendar.io/docs/select-callback
+     */
+    // public function onEventSelect($start, $end, $allDay): void
+    // {
+    //     //
+    // }
+
+    public static function isListeningSelectEvent(): bool
+    {
+        return method_exists(static::class, 'onEventSelect');
+    }
 }


### PR DESCRIPTION
This adds the Fullcalendar select event so that when a date is selected it will fire the event.

This will also use the create event modal and will populate the start and end date in the form.