### PR TITLE
feat: change modal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ public function onEventDrop($newEvent, $oldEvent, $relatedEvents): void
 
 Since [v1.0.0](https://github.com/saade/filament-fullcalendar/releases/tag/v1.0.0) you can create and edit events using a modal.
 
+To change the modal size, override the `protected string $modalWidth` property in your widget.
+
 The process of saving and editing the event is up to you, since this plugin does not rely on a Model to save the calendar events.
 
 

--- a/resources/views/components/create-event-modal.blade.php
+++ b/resources/views/components/create-event-modal.blade.php
@@ -1,4 +1,4 @@
-<x-filament::modal id="fullcalendar--create-event-modal">
+<x-filament::modal id="fullcalendar--create-event-modal" :width="$this->getModalWidth()">
     <x-slot name="heading">
         {{ __('filament::resources/pages/create-record.title', ['label' => 'Event']) }}
     </x-slot>

--- a/resources/views/components/edit-event-modal.blade.php
+++ b/resources/views/components/edit-event-modal.blade.php
@@ -1,4 +1,4 @@
-<x-filament::modal id="fullcalendar--edit-event-modal">
+<x-filament::modal id="fullcalendar--edit-event-modal" :width="$this->getModalWidth()">
     <x-slot name="heading">
         {{ __('filament::resources/pages/edit-record.title', ['label' => 'Event']) }}
     </x-slot>

--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -15,6 +15,8 @@ trait CanManageEvents
     use EditEventForm;
     use EvaluateClosures;
 
+    protected string $modalWidth = 'sm';
+
     protected function setUpForms(): void
     {
         if (static::canCreate()) {
@@ -32,6 +34,11 @@ trait CanManageEvents
             ...$this->getCreateEventForm(),
             ...$this->getEditEventForm(),
         ];
+    }
+
+    protected function getModalWidth(): string
+    {
+        return $this->modalWidth;
     }
 
     public function onEventClick($event): void


### PR DESCRIPTION
This will allow the modal size to be changed. The sizes are the same as what is allowed by the Filament support modal.

I also thought that we could maybe add a default modal size in the config but would require the config to be restructured into fullcalendar array of configs and widget array of configs.