### PR TITLE
fix: correct onEventDrop parameter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ public function onEventClick($event): void
 /**
  * Triggered when dragging stops and the event has moved to a different day/time.
  */
-public function onEventDrop($oldEvent, $newEvent, $relatedEvents): void
+public function onEventDrop($newEvent, $oldEvent, $relatedEvents): void
 {
-    parent::onEventDrop($oldEvent, $newEvent, $relatedEvents);
+    parent::onEventDrop($newEvent, $oldEvent, $relatedEvents);
 
     // your code
 }

--- a/src/Widgets/Concerns/FiresEvents.php
+++ b/src/Widgets/Concerns/FiresEvents.php
@@ -26,7 +26,7 @@ trait FiresEvents
      * Commented out so we can save some requests :) Feel free to extend it.
      * @see https://fullcalendar.io/docs/eventDrop
      */
-    // public function onEventDrop($oldEvent, $newEvent, $relatedEvents): void
+    // public function onEventDrop($newEvent, $oldEvent, $relatedEvents): void
     // {
     //     //
     // }


### PR DESCRIPTION
The order returned from fullcalendar eventDrop is $newEvent, $oldEvent, $relatedEvents.