### PR TITLE
fix: add default onEventDrop method

### DIFF
--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -45,6 +45,11 @@ trait CanManageEvents
         $this->dispatchBrowserEvent('open-modal', ['id' => 'fullcalendar--edit-event-modal']);
     }
 
+    public function onEventDrop($newEvent, $oldEvent, $relatedEvents): void
+    {
+        $this->onEventClick($newEvent);
+    }
+
     public function onCreateEventClick(array $date): void
     {
         if (! static::canCreate()) {


### PR DESCRIPTION
The readme says to add the `parent::onEventDrop` method when overriding the `onEventDrop` method but no such method exists. 