### PR TITLE
refactor: property type hints

### DIFF
--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -9,6 +9,10 @@ use Saade\FilamentFullCalendar\Widgets\Forms\CreateEventForm;
 use Saade\FilamentFullCalendar\Widgets\Forms\EditEventForm;
 use Saade\FilamentFullCalendar\Widgets\FullCalendarWidget;
 
+/**
+ * @property \Filament\Forms\ComponentContainer $createEventForm
+ * @property \Filament\Forms\ComponentContainer $editEventForm
+ */
 trait CanManageEvents
 {
     use AuthorizesActions;


### PR DESCRIPTION
When running PHP static analyser it fails as it can't resolve the properties `$createEventForm` and `$editEventForm`.