### PR TITLE
feat: Livewire event triggered for cancelled modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,17 @@ class CalendarWidget extends FullCalendarWidget
 
 <br>
 
+## Listening for cancelled modal
+
+If you want to know when a modal has been cancelled, you can add for the following [Livewire events](https://laravel-livewire.com/docs/2.x/events#event-listeners) to your widgets `$listener` array:
+
+```php
+    protected $listeners = [
+        'cancelledFullcalendarCreateEventModal' => 'onCreateEventCancelled',
+        'cancelledFullcalendarEditEventModal' => 'onEditEventCancelled',
+    ];
+```
+
 # Refreshing calendar events
 
 If you want to refresh the calendar events, you can call `$this->refreshEvents()` inside your widget class. This will call `getViewData()` and re-render the events on the calendar.

--- a/resources/views/components/create-event-modal.blade.php
+++ b/resources/views/components/create-event-modal.blade.php
@@ -6,6 +6,10 @@
             </x-filament::modal.heading>
         </x-slot>
 
+        @if($this->isListeningCancelledCreateModal())
+            <div x-on:close-modal.window="if ($event.detail.id === 'fullcalendar--create-event-modal') Livewire.emit('cancelledFullcalendarCreateEventModal')"></div>
+        @endif
+
         {{ $this->createEventForm }}
 
         <x-slot name="footer">
@@ -13,9 +17,15 @@
                 {{ __('filament::resources/pages/create-record.form.actions.create.label') }}
             </x-filament::button>
 
-            <x-filament::button color="secondary" x-on:click="isOpen = false">
-                {{ __('filament::resources/pages/create-record.form.actions.cancel.label') }}
-            </x-filament::button>
+            @if($this->isListeningCancelledCreateModal())
+                <x-filament::button color="secondary" x-on:click="isOpen = false; Livewire.emit('cancelledFullcalendarCreateEventModal')">
+                    {{ __('filament::resources/pages/create-record.form.actions.cancel.label') }}
+                </x-filament::button>
+            @else
+                <x-filament::button color="secondary" x-on:click="isOpen = false">
+                    {{ __('filament::resources/pages/create-record.form.actions.cancel.label') }}
+                </x-filament::button>
+            @endif
         </x-slot>
     </x-filament::modal>
 </x-filament::form>

--- a/resources/views/components/edit-event-modal.blade.php
+++ b/resources/views/components/edit-event-modal.blade.php
@@ -6,6 +6,10 @@
             </x-filament::modal.heading>
         </x-slot>
 
+        @if($this->isListeningCancelledEditModal())
+            <div x-on:close-modal.window="if ($event.detail.id === 'fullcalendar--create-event-modal') Livewire.emit('cancelledFullcalendarEditEventModal')"></div>
+        @endif
+
         {{ $this->editEventForm }}
 
         <x-slot name="footer">
@@ -13,9 +17,15 @@
                 {{ __('filament::resources/pages/edit-record.form.actions.save.label') }}
             </x-filament::button>
 
-            <x-filament::button color="secondary" x-on:click="isOpen = false">
-                {{ __('filament::resources/pages/edit-record.form.actions.cancel.label') }}
-            </x-filament::button>
+            @if($this->isListeningCancelledEditModal())
+                <x-filament::button color="secondary" x-on:click="isOpen = false; Livewire.emit('cancelledFullcalendarEditEventModal')">
+                    {{ __('filament::resources/pages/edit-record.form.actions.cancel.label') }}
+                </x-filament::button>
+            @else
+                <x-filament::button color="secondary" x-on:click="isOpen = false">
+                    {{ __('filament::resources/pages/edit-record.form.actions.cancel.label') }}
+                </x-filament::button>
+            @endif
         </x-slot>
     </x-filament::modal>
 </x-filament::form>

--- a/src/Widgets/Concerns/CanManageModals.php
+++ b/src/Widgets/Concerns/CanManageModals.php
@@ -17,4 +17,14 @@ trait CanManageModals
     {
         return $this->modalWidth;
     }
+
+    public function isListeningCancelledEditModal(): bool
+    {
+        return in_array('cancelledFullcalendarEditEventModal', $this->getEventsBeingListenedFor());
+    }
+
+    public function isListeningCancelledCreateModal(): bool
+    {
+        return in_array('cancelledFullcalendarCreateEventModal', $this->getEventsBeingListenedFor());
+    }
 }


### PR DESCRIPTION
This will add the ability to listen for when a modal is cancelled.

I believe this is useful as I sometimes want to trigger a side effect based on the user cancelling creating/editing the event.

This should have no impact if not used, as the Livewire event is only triggered if the widget is listening for the event.