### PR TITLE
Change record to event

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,17 +240,17 @@ public function editEvent(array $data): void
 
     /**
      * here you can access to 2 properties to perform update
-     * 1. $this->record_id
-     * 2. $this->record
+     * 1. $this->event_id
+     * 2. $this->event
     */
 
-    # $this->record_id
+    # $this->event_id
     // the value is retrieved from event's id key
-    // eg: Appointment::find($this->record);
+    // eg: Appointment::find($this->event);
 
-    # $this->record
+    # $this->event
     // model instance is resolved by user defined resolveEventRecord() funtion. See example below
-    // eg: $this->record->update($data);
+    // eg: $this->event->update($data);
 
 }
 

--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -21,9 +21,9 @@ trait CanManageEvents
     use EditEventForm;
     use EvaluateClosures;
 
-    public ?int $record_id = null;
+    public ?int $event_id = null;
 
-    public ?Model $record = null;
+    public ?Model $event = null;
 
     protected function setUpForms(): void
     {
@@ -53,9 +53,9 @@ trait CanManageEvents
         $this->editEventForm->fill($event);
 
         if (method_exists($this, 'resolveEventRecord')) {
-            $this->record = $this->resolveEventRecord($event);
+            $this->event = $this->resolveEventRecord($event);
         } else {
-            $this->record_id = $event['id'] ?? null;
+            $this->event_id = $event['id'] ?? null;
         }
 
         $this->dispatchBrowserEvent('open-modal', ['id' => 'fullcalendar--edit-event-modal']);


### PR DESCRIPTION
Change record, record_id to event, event_id to prevent conflicts when using the widget in a resource (view or edit) as $record is already used.