### PR TITLE
Add View Modal and corresponding canView authorization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,21 @@ protected static function getEditEventFormSchema(): array
 
 ## Authorizing actions
 
+If you want to authorize the `view` action, you can override the default authorization methods that comes with this package.
+
+```php
+public static function canView(?array $event = null): bool
+{
+    // When event is null, MAKE SURE you allow View otherwise the entire widget/calendar won't be rendered
+    if ($event === null) {
+        return true;
+    }
+    
+    // Returning 'false' will not show the event Modal.
+    return true;
+}
+```
+
 If you want to authorize the `edit` or `create` action, you can override the default authorization methods that comes with this package.
 
 ```php

--- a/resources/views/components/edit-event-modal.blade.php
+++ b/resources/views/components/edit-event-modal.blade.php
@@ -2,7 +2,11 @@
     <x-filament::modal id="fullcalendar--edit-event-modal" :width="$this->getModalWidth()">
         <x-slot name="header">
             <x-filament::modal.heading>
-                {{ __('filament::resources/pages/edit-record.title', ['label' => $this->getModalLabel()]) }}
+                {{
+                    $this->editEventForm->isDisabled()
+                        ? __('filament::resources/pages/view-record.title', ['label' => $this->getModalLabel()])
+                        : __('filament::resources/pages/edit-record.title', ['label' => $this->getModalLabel()])
+                }}
             </x-filament::modal.heading>
         </x-slot>
 
@@ -13,19 +17,30 @@
         {{ $this->editEventForm }}
 
         <x-slot name="footer">
-            <x-filament::button type="submit" form="onEditEventSubmit">
-                {{ __('filament::resources/pages/edit-record.form.actions.save.label') }}
-            </x-filament::button>
+            @if(!$this->editEventForm->isDisabled())
+                <x-filament::button type="submit" form="onEditEventSubmit">
+                    {{ __('filament::resources/pages/edit-record.form.actions.save.label') }}
+                </x-filament::button>
+            @endif
 
             @if($this->isListeningCancelledEditModal())
-                <x-filament::button color="secondary" x-on:click="isOpen = false; Livewire.emit('cancelledFullcalendarEditEventModal')">
-                    {{ __('filament::resources/pages/edit-record.form.actions.cancel.label') }}
+                <x-filament::button color="secondary"
+                                    x-on:click="isOpen = false; Livewire.emit('cancelledFullcalendarEditEventModal')">
+                    {{
+                        $this->editEventForm->isDisabled()
+                        ?  __('filament-support::actions/view.single.modal.actions.close.label')
+                        : __('filament::resources/pages/edit-record.form.actions.cancel.label')
+                     }}
                 </x-filament::button>
             @else
                 <x-filament::button color="secondary" x-on:click="isOpen = false">
-                    {{ __('filament::resources/pages/edit-record.form.actions.cancel.label') }}
+                    {{
+                        $this->editEventForm->isDisabled()
+                        ?  __('filament-support::actions/view.single.modal.actions.close.label')
+                        : __('filament::resources/pages/edit-record.form.actions.cancel.label')
+                     }}
                 </x-filament::button>
-            @endif
+                @endif
         </x-slot>
     </x-filament::modal>
 </x-filament::form>

--- a/src/Widgets/Concerns/AuthorizesActions.php
+++ b/src/Widgets/Concerns/AuthorizesActions.php
@@ -4,6 +4,16 @@ namespace Saade\FilamentFullCalendar\Widgets\Concerns;
 
 trait AuthorizesActions
 {
+    public static function canView(?array $event = null): bool
+    {
+        // If we want to prevent breaking changes, we need to "fallback"
+        // to "canEdit(Event)". Not doing that since the new behaviour
+        // is likely the desired one. The fallback would be:
+        // return static::canEdit($event);
+
+        return true;
+    }
+
     public static function canCreate(): bool
     {
         return true;

--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentFullCalendar\Widgets\Concerns;
 
 use Closure;
+use Filament\Forms\ComponentContainer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Saade\FilamentFullCalendar\Widgets\Forms\CreateEventForm;
@@ -10,8 +11,8 @@ use Saade\FilamentFullCalendar\Widgets\Forms\EditEventForm;
 use Saade\FilamentFullCalendar\Widgets\FullCalendarWidget;
 
 /**
- * @property \Filament\Forms\ComponentContainer $createEventForm
- * @property \Filament\Forms\ComponentContainer $editEventForm
+ * @property ComponentContainer $createEventForm
+ * @property ComponentContainer $editEventForm
  */
 trait CanManageEvents
 {
@@ -22,7 +23,6 @@ trait CanManageEvents
     use EvaluateClosures;
 
     public ?int $event_id = null;
-
     public ?Model $event = null;
 
     protected function setUpForms(): void
@@ -46,11 +46,13 @@ trait CanManageEvents
 
     public function onEventClick($event): void
     {
-        if (! static::canEdit($event)) {
+        if (!static::canView($event)) {
             return;
         }
 
-        $this->editEventForm->fill($event);
+        $this->editEventForm
+            ->disabled(!static::canView($event))
+            ->fill($event);
 
         if (method_exists($this, 'resolveEventRecord')) {
             $this->event = $this->resolveEventRecord($event);
@@ -63,7 +65,7 @@ trait CanManageEvents
 
     public function onCreateEventClick(array $date): void
     {
-        if (! static::canCreate()) {
+        if (!static::canCreate()) {
             return;
         }
 


### PR DESCRIPTION
Related to #45 .

Note that `canView()` behaves the same way as `canEdit()` in the sense that, since it overrides a Widget method, it well be called with without parameters by filament.
