### PR TITLE
Saves relationships

### DIFF
--- a/src/Widgets/Forms/CreateEventForm.php
+++ b/src/Widgets/Forms/CreateEventForm.php
@@ -3,6 +3,7 @@
 namespace Saade\FilamentFullCalendar\Widgets\Forms;
 
 use Filament\Forms;
+use Illuminate\Database\Eloquent\Model;
 
 trait CreateEventForm
 {
@@ -10,12 +11,16 @@ trait CreateEventForm
 
     public function onCreateEventSubmit()
     {
-        $this->createEvent($this->createEventForm->getState());
+        $eventModel = $this->createEvent($this->createEventForm->getState());
+        if ($eventModel) {
+            $this->createEventForm->model($eventModel);
+            $this->createEventForm->saveRelationships();
+        }
 
         $this->dispatchBrowserEvent('close-modal', ['id' => 'fullcalendar--create-event-modal']);
     }
 
-    public function createEvent(array $data): void
+    public function createEvent(array $data): ?Model
     {
         // Override this function and do whatever you want with $data
     }


### PR DESCRIPTION
If the create form has relationships, save the relationships as well.
For this to work, the dev needs to return the created model from the `createEvent() `override, like so:

```php
public function createEvent(array $data): ?Model
{
    if ($booking = Booking::createFromFullCalendarEventData($data)) {
        Notification::make()->title(__('Created successfully'))->success()->send();
    } else {
        Notification::make()->title(__('Create failed'))->warning()->send();
    }

    // Always refresh the UI
    $this->refreshEvents();

    return $booking;
}
```