### PR TITLE
feat: save state

### DIFF
--- a/art/fullcalendar-widget.png:Zone.Identifier
+++ b/art/fullcalendar-widget.png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-LastWriterPackageFamilyName=Microsoft.ScreenSketch_8wekyb3d8bbwe
-ZoneId=3

--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -68,6 +68,16 @@
                         @endif
                     }
 
+                    @if($this->config('saveState', false))
+                    const key = "{{ $this->getKey() }}";
+                    const initialView =
+                        localStorage.getItem("fullcalendar.view." + key) ??
+                            @json($this->config('initialView'));
+                    const initialDate =
+                        localStorage.getItem("fullcalendar.date." + key) ??
+                            @json($this->config('initialDate'));
+                    @endif
+
                     const calendar = new FullCalendar.Calendar($el, {
                         ...config,
                         locale,
@@ -79,7 +89,15 @@
                         eventSources:[
                             { events },
                             fetchEvents
-                        ]
+                        ],
+                        @if($this->config('saveState', false))
+                        initialView: initialView ?? undefined,
+                        initialDate: initialDate ?? undefined,
+                        datesSet: function ({start, view}) {
+                            localStorage.setItem("fullcalendar.view." + key, view.type);
+                            localStorage.setItem("fullcalendar.date." + key, start.toISOString());
+                        },
+                        @endif
                     });
 
                     calendar.render();

--- a/src/Widgets/FullCalendarWidget.php
+++ b/src/Widgets/FullCalendarWidget.php
@@ -17,7 +17,6 @@ class FullCalendarWidget extends Widget implements HasForms
     use InteractsWithForms, CanManageEvents {
         CanManageEvents::getForms insteadof InteractsWithForms;
     }
-
     use CanRefreshEvents;
     use CanFetchEvents;
     use FiresEvents;
@@ -38,5 +37,10 @@ class FullCalendarWidget extends Widget implements HasForms
             ->with([
                 'events' => $this->getViewData(),
             ]);
+    }
+
+    public function getKey(): string
+    {
+        return $this->key ?? 'default';
     }
 }


### PR DESCRIPTION
Saves current view type and date to `localStorage`.

### Known issues:

- For `dayGridMonth` view, it only works when `showNonCurrentDates` is set to `false`.