### PR TITLE
Fixes wrong permissions check.

### DIFF
--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -101,7 +101,7 @@
         <x:filament-fullcalendar::create-event-modal />
     @endif
 
-    @if($this::canEdit())
+    @if($this::canView())
         <x:filament-fullcalendar::edit-event-modal />
     @endif
 </x-filament::widget>

--- a/src/Widgets/Concerns/CanManageEvents.php
+++ b/src/Widgets/Concerns/CanManageEvents.php
@@ -51,7 +51,7 @@ trait CanManageEvents
         }
 
         $this->editEventForm
-            ->disabled(! static::canView($event))
+            ->disabled(! static::canEdit($event))
             ->fill($event);
 
         if (method_exists($this, 'resolveEventRecord')) {


### PR DESCRIPTION
The edit-event-modal must be shown if the user can only View (and not edit).
Additionally, the permission to decide whether the form should be disabled is `canEdit` and not `canView`

These are bugs from my previous PR, sorry.