### PR TITLE
fix modal not closed after create/edit

### DIFF
--- a/src/Widgets/Forms/CreateEventForm.php
+++ b/src/Widgets/Forms/CreateEventForm.php
@@ -12,7 +12,7 @@ trait CreateEventForm
     {
         $this->createEvent($this->createEventForm->getState());
 
-        $this->dispatch('close-modal', ['id' => 'fullcalendar--create-event-modal']);
+        $this->dispatch('close-modal', id: 'fullcalendar--create-event-modal');
     }
 
     public function createEvent(array $data): void

--- a/src/Widgets/Forms/EditEventForm.php
+++ b/src/Widgets/Forms/EditEventForm.php
@@ -12,7 +12,7 @@ trait EditEventForm
     {
         $this->editEvent($this->editEventForm->getState());
 
-        $this->dispatch('close-modal', ['id' => 'fullcalendar--edit-event-modal']);
+        $this->dispatch('close-modal', id: 'fullcalendar--edit-event-modal');
     }
 
     public function editEvent(array $data): void


### PR DESCRIPTION
base on [Livewire v3](https://livewire.laravel.com/docs/events#dispatching-events) the second parameter in dispatch is not an associative array but using named arguments.