### PR TITLE
Set Timeline to false to remove license warning by default

### DIFF
--- a/config/filament-fullcalendar.php
+++ b/config/filament-fullcalendar.php
@@ -18,7 +18,7 @@ return [
         'interaction' => true,
         'list' => true,
         'rrule' => true,
-        'resourceTimeline' => true,
+        'resourceTimeline' => false,
     ],
 
     'headerToolbar' => [


### PR DESCRIPTION
Will avoid getting license warning by default