### PR TITLE
Fix "Can't set model as property if it hasn't been persisted yet" after deleting a record.

### DIFF
--- a/src/Actions/DeleteAction.php
+++ b/src/Actions/DeleteAction.php
@@ -20,7 +20,10 @@ class DeleteAction extends BaseDeleteAction
         );
 
         $this->after(
-            fn (FullCalendarWidget $livewire) => $livewire->refreshRecords()
+            function (FullCalendarWidget $livewire) {
+                $livewire->record = null;
+                $livewire->refreshRecords();
+            }
         );
 
         $this->cancelParentActions();


### PR DESCRIPTION
I got error "Can't set model as property if it hasn't been persisted yet" when deleting a record. I'm trying to find the solution in discord but no response about [this](https://discord.com/channels/883083792112300104/935819320699805737/1156504533871116318). 

So in Livewire 3 it seems we must persist the property. this PR solve my issue.

Reference:
[Livewire 3 : Can't set model as property if it hasn't been persisted yet](https://laracasts.com/discuss/channels/livewire/livewire-3-cant-set-model-as-property-if-it-hasnt-been-persisted-yet)
[ModelSynth](https://github.com/livewire/livewire/blob/68e4570135e06a693e7e20a7f7caded84c9b7ac9/src/Features/SupportModels/ModelSynth.php#L18)
