### PR TITLE
Update fullcalendar.blade.php with correct namespace

### DIFF
--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -1,5 +1,5 @@
 @php
-    $plugin = \Saade\FilamentFullcalendar\FilamentFullCalendarPlugin::get();
+    $plugin = \Saade\FilamentFullCalendar\FilamentFullCalendarPlugin::get();
 @endphp
 
 <x-filament-widgets::widget>


### PR DESCRIPTION
Fixed incorrect namespace case for FilamentFullCalendar in `resources/views/fullcalendar.blade.php`