### PR TITLE
fix resolving the model

### DIFF
--- a/src/Widgets/Concerns/InteractsWithRecords.php
+++ b/src/Widgets/Concerns/InteractsWithRecords.php
@@ -72,7 +72,7 @@ trait InteractsWithRecords
 
     protected function getEloquentQuery(): Builder
     {
-        $query = $this->model::query();
+        $query =  app($this->getModel())::query();
 
         // TODO: Scope query to tenant.
 


### PR DESCRIPTION
in some cases, need to get the model dynamically or conditionally, so I am using the method:

```php
public function getModel(): ?string
{
    return myMode::class;
}
```

I'll get the error:
`Class name must be a valid object or a string`

raised from:

```php
protected function getEloquentQuery(): Builder
{
    $query = $this->model::query(); //error

    // TODO: Scope query to tenant.

    return $query;
}
```

the solution will be to access the model from the getter or resolve it by the container

```php
protected function getEloquentQuery(): Builder
{
    $query = app($this->getModel())::query(); //fix

    // TODO: Scope query to tenant.

    return $query;
}
```