### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ class CalendarWidget extends FullCalendarWidget
                         url: EventResource::getUrl(name: 'view', parameters: ['record' => $event]),
                         shouldOpenUrlInNewTab: true
                     )
+                    ->toArray()
             )
             ->all();
     }
@@ -273,7 +274,9 @@ The locale to use when displaying texts and dates. See: [locale](https://fullcal
 `locale` (Default: `config('app.locale')`)
 
 ### plugins(`array` $plugins, `bool` $merge)
-The plugins to enable. You can add more plugins if you wish, or replace the default ones by passing `false` as the second param for the method. See: [plugins](https://fullcalendar.io/docs/plugin-index)
+The plugins to enable. You can add more plugins if you wish, or replace the default ones by passing `false` as the second param for the method. 
+Avaliable: `interaction, dayGrid, timeGrid, list, multiMonth, scrollGrid, timeline, adaptive, resource, resourceDayGrid, resourceTimeline, resourceTimeGrid, rrule, moment, momentTimezone`
+See: [plugins](https://fullcalendar.io/docs/plugin-index)
 
 `plugins` Default: `['dayGrid', 'timeGrid']`
 `merge` Default: `true`

--- a/README.md
+++ b/README.md
@@ -176,9 +176,8 @@ class CalendarWidget extends FullCalendarWidget
                         url: EventResource::getUrl(name: 'view', parameters: ['record' => $event]),
                         shouldOpenUrlInNewTab: true
                     )
-                    ->toArray()
             )
-            ->all();
+            ->toArray();
     }
 }
 ```


### PR DESCRIPTION
Add `->toArray` method to code examples, when usung `EventData` object. Also added avaliable plugins, because their names are different from original Full Calendar Docs, for example: 'resourceTimeline'. 