### PR TITLE
Fix button vertical spacing on toolbar

### DIFF
--- a/resources/css/filament-fullcalendar.css
+++ b/resources/css/filament-fullcalendar.css
@@ -54,10 +54,6 @@ html.dark .filament-fullcalendar {
     --fc-list-event-hover-bg-color: rgba(var(--gray-800), .8);
 }
 
-.filament-fullcalendar .fc-toolbar-chunk {
-    @apply space-y-1;
-}
-
 .filament-fullcalendar .fc-toolbar-title {
     @apply !text-lg leading-5 md:!text-3xl;
 }


### PR DESCRIPTION
This PR removes the applied vertical spacing to the toolbar chunk, which currently results in one button being offset slightly different. The applied `space-y-1` utility results in any visible child that is not the first child to have a top margin. Since the list is flowing horizontally however, in this case, it just results in the second button being out of place:

![CleanShot 2025-02-21 at 13 37 57@2x](https://github.com/user-attachments/assets/d386b778-9406-4073-a8b0-edb1a7755ff5)

A quick note: I meant to open this as an issue first, but I cannot currently open any issues. When trying to open an issue, this happens:

![CleanShot 2025-02-21 at 13 52 04@2x](https://github.com/user-attachments/assets/70ee8818-26a6-4a28-9d6a-ec452524d455)

Cheers
