### PR TITLE
Fix breaking change in AsyncAlpine v2 where attributes were renamed

### DIFF
--- a/resources/views/fullcalendar.blade.php
+++ b/resources/views/fullcalendar.blade.php
@@ -8,8 +8,8 @@
             <x-filament-actions::actions :actions="$this->getCachedHeaderActions()" class="shrink-0" />
         </div>
 
-        <div class="filament-fullcalendar" wire:ignore ax-load
-            ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-fullcalendar-alpine', 'saade/filament-fullcalendar') }}"
+        <div class="filament-fullcalendar" wire:ignore x-load
+            x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('filament-fullcalendar-alpine', 'saade/filament-fullcalendar') }}"
             ax-load-css="{{ \Filament\Support\Facades\FilamentAsset::getStyleHref('filament-fullcalendar-styles', 'saade/filament-fullcalendar') }}"
             x-ignore x-data="fullcalendar({
                 locale: @js($plugin->getLocale()),


### PR DESCRIPTION
This commit on Filament https://github.com/filamentphp/filament/commit/af36dec35113be5747e12f013dd288d7287ce533 upgraded AsyncAlpine from v1 to v2, which has a major breaking change (https://async-alpine.dev/docs/upgrade). The attributes ax-load and ax-load-src dropped the "a" and now are called x-load and x-load-src.

## Before: 

https://github.com/user-attachments/assets/d089df89-134d-4466-a879-be702d6f90e4

## After: 

https://github.com/user-attachments/assets/fab817db-cfca-4efa-b38c-1327f169483e

