### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.0, 8.1, '8.2', '8.3', '8.4']
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -26,11 +26,19 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
         exclude:
           - laravel: 12.*
             php: 8.0
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.0
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: '8.2'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^3.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {


### PR DESCRIPTION
Adds Laravel 13 support to the `3.x` (Filament v3) line, mirroring #271 which added Laravel 13 support to the `4.x` branch.

## Summary
- `illuminate/contracts`: `^10.0|^11.0|^12.0` → `^10.0|^11.0|^12.0|^13.0`
- CI: add `13.*` to the test matrix (`testbench: 11.*`, excluding PHP < 8.3), matching #271

No source changes are required — the package uses only stable APIs (`Carbon::parse`, Eloquent `Model`/`Builder` type-hints, Filament v3 / Livewire v3 components), none of which changed in Laravel 13. This matches #271 on the `4.x` line, which needed no source changes either.